### PR TITLE
Update property names and a couple versions

### DIFF
--- a/jboss-javaee-6.0-with-infinispan/pom.xml
+++ b/jboss-javaee-6.0-with-infinispan/pom.xml
@@ -70,7 +70,7 @@
                     we ensure we are using a version compatible with Arquillian -->
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${version.org.apache.maven.surefire.plugin}</version>
+                    <version>${version.surefire.plugin}</version>
                 </plugin>
                 <!-- The JBoss AS plugin deploys your war to a local JBoss 
                     AS container -->
@@ -79,7 +79,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>${version.org.jboss.as.plugins.jboss.as.maven.plugin}</version>
+                    <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/jboss-javaee-6.0-with-logging/pom.xml
+++ b/jboss-javaee-6.0-with-logging/pom.xml
@@ -77,7 +77,7 @@
                 <!-- The Maven Surefire plugin tests your application. Here we ensure we are using a version compatible with Arquillian -->
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${version.org.apache.maven.surefire.plugin}</version>
+                    <version>${version.surefire.plugin}</version>
                 </plugin>
                 <!-- The JBoss AS plugin deploys your war to a local JBoss AS container -->
                 <!-- To use, set the JBOSS_HOME environment variable and run:
@@ -85,7 +85,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>${version.org.jboss.as.plugins.jboss.as.maven.plugin}</version>
+                    <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/jboss-javaee-6.0-with-osgi/pom.xml
+++ b/jboss-javaee-6.0-with-osgi/pom.xml
@@ -62,7 +62,7 @@
                 <!-- The Maven Surefire plugin tests your application. Here we ensure we are using a version compatible with Arquillian -->
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${version.org.apache.maven.surefire.plugin}</version>
+                    <version>${version.surefire.plugin}</version>
                 </plugin>
                 <!-- The JBoss AS plugin deploys your war to a local JBoss AS container -->
                 <!-- To use, set the JBOSS_HOME environment variable and run:
@@ -70,7 +70,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>${version.org.jboss.as.plugins.jboss.as.maven.plugin}</version>
+                    <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/jboss-javaee-6.0-with-richfaces/pom.xml
+++ b/jboss-javaee-6.0-with-richfaces/pom.xml
@@ -66,7 +66,7 @@
                 <!-- The Maven Surefire plugin tests your application. Here we ensure we are using a version compatible with Arquillian -->
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${version.org.apache.maven.surefire.plugin}</version>
+                    <version>${version.surefire.plugin}</version>
                 </plugin>
                 <!-- The JBoss AS plugin deploys your war to a local JBoss AS container -->
                 <!-- To use, set the JBOSS_HOME environment variable and run:
@@ -74,7 +74,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>${version.org.jboss.as.plugins.jboss.as.maven.plugin}</version>
+                    <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/jboss-javaee-6.0-with-tools/pom.xml
+++ b/jboss-javaee-6.0-with-tools/pom.xml
@@ -129,7 +129,7 @@
                 <!-- The Maven Surefire plugin tests your application. Here we ensure we are using a version compatible with Arquillian -->
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${version.org.apache.maven.surefire.plugin}</version>
+                    <version>${version.surefire.plugin}</version>
                 </plugin>
                 <!-- The JBoss AS plugin deploys your war to a local JBoss AS container -->
                 <!-- To use, set the JBOSS_HOME environment variable and run:
@@ -137,7 +137,7 @@
                 <plugin>
                     <groupId>org.jboss.as.plugins</groupId>
                     <artifactId>jboss-as-maven-plugin</artifactId>
-                    <version>${version.org.jboss.as.plugins.jboss.as.maven.plugin}</version>
+                    <version>${version.org.jboss.as.plugins.maven.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <version.org.jboss.errai>2.0.0.Final</version.org.jboss.errai>
         <version.org.jboss.jbossts.jbossjts>4.16.4.Final</version.org.jboss.jbossts.jbossjts>
         <version.org.jboss.logging>3.1.0.GA</version.org.jboss.logging>
-        <version.org.jboss.logging.processor>1.0.1.Final</version.org.jboss.logging.processor>
+        <version.org.jboss.logging.processor>1.0.3.Final</version.org.jboss.logging.processor>
         <version.org.jboss.security.negotiation>2.1.1.Final</version.org.jboss.security.negotiation>
         <version.org.jboss.spec.jboss.javaee.6.0>3.0.0.Final</version.org.jboss.spec.jboss.javaee.6.0>
         <version.org.richfaces>4.2.0.Final</version.org.richfaces>
@@ -84,9 +84,9 @@
         <version.org.testng>5.14.6</version.org.testng>
 
         <!-- Versions of Maven plugins, user must setup them by his/her own -->
-        <version.org.apache.maven.surefire.plugin>2.10</version.org.apache.maven.surefire.plugin>
+        <version.surefire.plugin>2.10</version.surefire.plugin>
         <version.org.codehaus.mojo.gwt.maven.plugin>${version.com.google.gwt}</version.org.codehaus.mojo.gwt.maven.plugin>
-        <version.org.jboss.as.plugins.jboss.as.maven.plugin>7.1.0.Final</version.org.jboss.as.plugins.jboss.as.maven.plugin>
+        <version.org.jboss.as.plugins.maven.plugin>7.2.Final</version.org.jboss.as.plugins.maven.plugin>
 
 
         <!-- Repository Deployment URLs -->


### PR DESCRIPTION
Renamed the jboss-as maven plugin to be slightly shorter. Also renamed the surefire plugin to match the property from the [jboss-parent-pom](https://github.com/jboss/jboss-parent-pom/blob/master/pom.xml#L109).

Updated the logging processor version and the jboss-as maven plugin version
