### PR TITLE
Updated for Errai 2.3.0.Final

### DIFF
--- a/jboss-javaee-6.0-with-errai/pom.xml
+++ b/jboss-javaee-6.0-with-errai/pom.xml
@@ -44,7 +44,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-  
+
             <!-- All Errai Modules -->
             <dependency>
               <groupId>org.jboss.errai</groupId>
@@ -63,12 +63,12 @@
             </dependency>
             <dependency>
               <groupId>org.jboss.errai</groupId>
-              <artifactId>errai-codegen-gwt</artifactId>
+              <artifactId>errai-codegen</artifactId>
               <version>${version.org.jboss.errai}</version>
             </dependency>
             <dependency>
               <groupId>org.jboss.errai</groupId>
-              <artifactId>errai-codegen</artifactId>
+              <artifactId>errai-codegen-gwt</artifactId>
               <version>${version.org.jboss.errai}</version>
             </dependency>
             <dependency>
@@ -81,26 +81,43 @@
               <artifactId>errai-config</artifactId>
               <version>${version.org.jboss.errai}</version>
             </dependency>
+
+            <!-- Coming in Errai 3.0
             <dependency>
               <groupId>org.jboss.errai</groupId>
               <artifactId>errai-cordova</artifactId>
               <version>${version.org.jboss.errai}</version>
             </dependency>
+            -->
+
             <dependency>
               <groupId>org.jboss.errai</groupId>
               <artifactId>errai-data-binding</artifactId>
               <version>${version.org.jboss.errai}</version>
             </dependency>
+
+            <!-- Coming in Errai 3.0
             <dependency>
               <groupId>org.jboss.errai</groupId>
-              <artifactId>errai-ioc-bus-support</artifactId>
+              <artifactId>errai-html5</artifactId>
               <version>${version.org.jboss.errai}</version>
             </dependency>
+            -->
+
             <dependency>
               <groupId>org.jboss.errai</groupId>
               <artifactId>errai-ioc</artifactId>
               <version>${version.org.jboss.errai}</version>
             </dependency>
+
+            <!-- Coming in Errai 3.0
+            <dependency>
+              <groupId>org.jboss.errai</groupId>
+              <artifactId>errai-ioc-bus-support</artifactId>
+              <version>${version.org.jboss.errai}</version>
+            </dependency>
+            -->
+
             <dependency>
               <groupId>org.jboss.errai</groupId>
               <artifactId>errai-javaee-all</artifactId>
@@ -121,6 +138,15 @@
               <artifactId>errai-jaxrs-provider</artifactId>
               <version>${version.org.jboss.errai}</version>
             </dependency>
+
+            <!-- Coming in Errai 3.0
+            <dependency>
+              <groupId>org.jboss.errai</groupId>
+              <artifactId>errai-jboss-as-support</artifactId>
+              <version>${version.org.jboss.errai}</version>
+            </dependency>
+            -->
+
             <dependency>
               <groupId>org.jboss.errai</groupId>
               <artifactId>errai-jpa-client</artifactId>
@@ -129,11 +155,6 @@
             <dependency>
               <groupId>org.jboss.errai</groupId>
               <artifactId>errai-js</artifactId>
-              <version>${version.org.jboss.errai}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.jboss.errai</groupId>
-              <artifactId>errai-location</artifactId>
               <version>${version.org.jboss.errai}</version>
             </dependency>
             <dependency>
@@ -163,14 +184,18 @@
             </dependency>
             <dependency>
               <groupId>org.jboss.errai</groupId>
-              <artifactId>errai-validation</artifactId>
-              <version>${version.org.jboss.errai}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.jboss.errai</groupId>
               <artifactId>errai-webworkers</artifactId>
               <version>${version.org.jboss.errai}</version>
             </dependency>
+
+            <!-- Coming in Errai 3.0
+            <dependency>
+              <groupId>org.jboss.errai</groupId>
+              <artifactId>errai-validation</artifactId>
+              <version>${version.org.jboss.errai}</version>
+            </dependency>
+            -->
+
             <dependency>
               <groupId>org.jboss.errai</groupId>
               <artifactId>errai-weld-integration</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <version.org.jboss.arquillian.extension.drone>1.1.1.Final</version.org.jboss.arquillian.extension.drone>
         <version.org.jboss.arquillian.graphene>1.0.0.Final</version.org.jboss.arquillian.graphene>
         <version.org.jboss.as.arquillian.container>7.1.3.Final</version.org.jboss.as.arquillian.container>
-        <version.org.jboss.errai>2.2.0.Final</version.org.jboss.errai>
+        <version.org.jboss.errai>2.3.0.Final</version.org.jboss.errai>
         <version.org.jboss.jbossts.jbossjts>4.16.4.Final</version.org.jboss.jbossts.jbossjts>
         <version.org.jboss.logging>3.1.0.GA</version.org.jboss.logging>
         <version.org.jboss.logging.processor>1.0.3.Final</version.org.jboss.logging.processor>
@@ -77,7 +77,7 @@
         <version.org.hibernate3.commons.annotations>3.2.0.Final</version.org.hibernate3.commons.annotations>
 
         <!-- Versions of projects not directly under JBoss umbrella -->
-        <version.com.google.gwt>2.4.0</version.com.google.gwt>
+        <version.com.google.gwt>2.5.1</version.com.google.gwt>
         <version.junit>4.10</version.junit>
         <version.log4j>1.2.16</version.log4j>
         <version.org.mvel>2.1.Beta8</version.org.mvel>


### PR DESCRIPTION
I've put included the modules that will exist in Errai 3.0 but don't yet exist in Errai 2.3.0 in comments. This is mainly for insurance so we don't forget to add them in for the next release of the Errai BOM.

If you don't like the look of the comments, let me know and I'll update the PR to lose them.
