### PR TITLE
Update for EAP 6.2.0 ER2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,26 +47,26 @@
         <!-- ############    E   A   P    P r o d u c t   V e r s i o n s  ############# -->
         
         <!-- JBoss projects -->
-        <version.org.jboss.jbossts.jbossjts>4.16.4.Final-redhat-1</version.org.jboss.jbossts.jbossjts>
+        <version.org.jboss.jbossts.jbossjts>4.17.10.Final-redhat-2</version.org.jboss.jbossts.jbossjts>
         <version.org.jboss.logging>3.1.2.GA-redhat-1</version.org.jboss.logging>
         <version.org.jboss.logging.processor>1.1.0.Final-redhat-1</version.org.jboss.logging.processor>
-        <version.org.jboss.security.negotiation>2.2.2.Final-redhat-1</version.org.jboss.security.negotiation>
-        <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final-redhat-2</version.org.jboss.spec.jboss.javaee.6.0>
+        <version.org.jboss.security.negotiation>2.2.5.Final-redhat-2</version.org.jboss.security.negotiation>
+        <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final-redhat-3</version.org.jboss.spec.jboss.javaee.6.0>
 
         <!-- Hibernate -->
-        <version.org.hibernate>4.2.0.SP1-redhat-1</version.org.hibernate>
+        <version.org.hibernate>4.2.5.Final-redhat-1</version.org.hibernate>
         <version.org.hibernate.validator>4.3.1.Final-redhat-1</version.org.hibernate.validator>
 
         <!-- Hibernate 3 -->
-        <version.org.hibernate3>3.6.10.Final</version.org.hibernate3>
+        <version.org.hibernate3>3.6.5.Final-redhat-2</version.org.hibernate3>
         <version.org.hibernate3.validator>3.1.0.GA</version.org.hibernate3.validator>
-        <version.org.hibernate3.commons.annotations>3.2.0.Final</version.org.hibernate3.commons.annotations>
+        <version.org.hibernate3.commons.annotations>3.2.0.Final-redhat-2</version.org.hibernate3.commons.annotations>
 
         <!-- RestEasy -->
-        <version.org.jboss.resteasy>2.3.6.Final-redhat-1</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>2.3.7.Final-redhat-1</version.org.jboss.resteasy>
         
         <!-- Picketlink -->
-        <version.org.picketlink>2.5.2.Final</version.org.picketlink>
+        <version.org.picketlink>2.1.6.3.Final-redhat-2</version.org.picketlink>
         
         <!-- ############   W  F  K     P r o d u c t   V e r s i o n s   ############### -->
         


### PR DESCRIPTION
This is update according to EAP 6.2.0 ER2 BOM. 

I noticed some versions are even higher than current EAP BOM:

<version.org.hibernate3>3.6.10.Final</version.org.hibernate3>
// the hibernate3 version is higher than current BOM, if you think it should be this way, I will change it back.

<version.org.picketlink>2.5.2.Final</version.org.picketlink> 
// this one has not been merged yet, should be updated for ER3
