### PR TITLE
[BZ:999846] Add jbossweb and jbossxacml to -with-security bom

### DIFF
--- a/jboss-javaee-6.0-with-security/pom.xml
+++ b/jboss-javaee-6.0-with-security/pom.xml
@@ -70,6 +70,11 @@
                 <version>${version.org.jboss.security.negotiation}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.web</groupId>
+                <artifactId>jbossweb</artifactId>
+                <version>${version.org.jboss.web}</version>
+            </dependency>
             
             <!-- PicketLink Dependencies -->
             <dependency>
@@ -81,6 +86,11 @@
                 <groupId>org.picketlink.distribution</groupId>
                 <artifactId>picketlink-jbas7</artifactId>
                 <version>${version.org.picketlink}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.security</groupId>
+                <artifactId>jbossxacml</artifactId>
+                <version>${version.org.jboss.security.jbossxacml}</version>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,12 @@
         
         <!-- Picketlink -->
         <version.org.picketlink>2.1.9.Final-redhat-1</version.org.picketlink>
+
+        <!-- JBossWeb, it is used in jboss security negotiation project -->
+        <version.org.jboss.web>7.2.2.Final-redhat-1</version.org.jboss.web>
+
+        <!-- JBossxacml, it is used by pikcetlink-core -->
+        <version.org.jboss.security.jbossxacml>2.0.8.Final-redhat-2</version.org.jboss.security.jbossxacml>
         
         <!-- ############   W  F  K     P r o d u c t   V e r s i o n s   ############### -->
         


### PR DESCRIPTION
Bugzilla reference: https://bugzilla.redhat.com/show_bug.cgi?id=999846

Both jbossweb and jbossxacml need to be added to -with-security bom, in case the customer's pom depends on each declared dependencies in the -with-security bom.
