### PR TITLE
Upgrade for EAP 6.2.2.CP.CR3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.org.picketlink>2.1.9.SP2-redhat-1</version.org.picketlink>
 
         <!-- JBossWeb, it is used in jboss security negotiation project -->
-        <version.org.jboss.web>7.3.0.Final-redhat-2</version.org.jboss.web>
+        <version.org.jboss.web>7.3.1.Final-redhat-1</version.org.jboss.web>
 
         <!-- JBossxacml, it is used by pikcetlink-core -->
         <version.org.jboss.security.jbossxacml>2.0.8.Final-redhat-5</version.org.jboss.security.jbossxacml>


### PR DESCRIPTION
Update version of JBoss Web for EAP 6.2.2.CP CR3.
