### PR TITLE
Upgrade jboss-logging-tools to version 1.2.0.Final from versoin 1.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <!-- JBoss projects -->
         <version.org.jboss.jbossts.jbossjts>4.17.19.Final-redhat-1</version.org.jboss.jbossts.jbossjts>
         <version.org.jboss.logging>3.1.4.GA-redhat-1</version.org.jboss.logging>
-        <version.org.jboss.logging.processor>1.1.0.Final</version.org.jboss.logging.processor>
+        <version.org.jboss.logging.processor>1.2.0.Final</version.org.jboss.logging.processor>
         <version.org.jboss.security.negotiation>2.3.0.Final-redhat-1</version.org.jboss.security.negotiation>
         <version.org.jboss.spec.jboss.javaee.6.0>3.0.2.Final-redhat-9</version.org.jboss.spec.jboss.javaee.6.0>
 


### PR DESCRIPTION
This version is greater than the version currently used in EAP, but this is a build time tool only. The version of the `jboss-logging` contains deprecated annotations that were moved to the tooling. The updated tooling contains the annotations to remove the warning messages during a build.
