### PR TITLE
Updated versions of Arquillian-core and of other Arquillian components

### DIFF
--- a/jboss-javaee-7.0-with-tools/pom.xml
+++ b/jboss-javaee-7.0-with-tools/pom.xml
@@ -79,14 +79,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- Arquillian Drone bindings for DefaultSelenium based browsers -->
-            <dependency>
-                <groupId>org.jboss.arquillian.extension</groupId>
-                <artifactId>arquillian-drone-selenium-depchain</artifactId>
-                <version>${version.org.jboss.arquillian.extension.drone}</version>
-                <type>pom</type>
-            </dependency>
-
             <!-- Arquillian Drone bindings for WebDriver based browsers -->
             <dependency>
                 <groupId>org.jboss.arquillian.extension</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <!-- Versions of JBoss projects -->
         <version.org.wildfly>10.0.0.Alpha5</version.org.wildfly>
         <version.org.infinispan>7.2.3.Final</version.org.infinispan>
-        <version.org.jboss.arquillian>1.1.7.Final</version.org.jboss.arquillian>
-        <version.org.jboss.arquillian.extension.drone>1.3.0.Final</version.org.jboss.arquillian.extension.drone>
+        <version.org.jboss.arquillian>1.1.8.Final</version.org.jboss.arquillian>
+        <version.org.jboss.arquillian.extension.drone>2.0.0.Alpha4</version.org.jboss.arquillian.extension.drone>
         <version.org.jboss.arquillian.graphene>2.0.3.Final</version.org.jboss.arquillian.graphene>
         <version.org.wildfly.arquillian.container>1.0.0.Final</version.org.wildfly.arquillian.container>
         <version.org.jboss.narayana>5.2.0.Final</version.org.jboss.narayana>
@@ -58,7 +58,7 @@
         <version.org.jboss.resteasy>3.0.11.Final</version.org.jboss.resteasy>
         <version.org.jboss.security.negotiation>2.3.7.Final</version.org.jboss.security.negotiation>
         <version.org.jboss.spec.jboss.javaee.7.0>1.0.3.Final</version.org.jboss.spec.jboss.javaee.7.0>
-        <version.org.jboss.shrinkwrap.resolver>2.0.0</version.org.jboss.shrinkwrap.resolver>
+        <version.org.jboss.shrinkwrap.resolver>2.1.1</version.org.jboss.shrinkwrap.resolver>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.picketlink>2.7.0.Final</version.org.picketlink>
 


### PR DESCRIPTION
Hi, I've updated:
- Arquillian-core to the latest 1.1.8.Final
- Arquillian-extension-drone to the latest 2.0.0.Alpha4 - we are working on Final version, that should be in EAP7 final release
- ShrinkWrap Resolver to the latest 2.1.1

Then I removed arquillian-drone-selenium-depchain dependency as it has been dropped in Drone 2.0.0-Alpha1 https://issues.jboss.org/browse/ARQ-1688
