### PR TITLE
Removal of SnowDrop from Spring4 BOM

### DIFF
--- a/jboss-javaee-7.0-with-spring4/pom.xml
+++ b/jboss-javaee-7.0-with-spring4/pom.xml
@@ -263,27 +263,7 @@
                 <artifactId>spring-xml</artifactId>
                 <version>${version.org.springframework.ws}</version>
             </dependency>
-            <!--  snowdrop  -->
-            <dependency>
-                <groupId>org.jboss.snowdrop</groupId>
-                <artifactId>snowdrop-vfs</artifactId>
-                <version>${version.snowdrop}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.snowdrop</groupId>
-                <artifactId>snowdrop-weaving</artifactId>
-                <version>${version.snowdrop}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.snowdrop</groupId>
-                <artifactId>snowdrop-interceptors</artifactId>
-                <version>${version.snowdrop}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.snowdrop</groupId>
-                <artifactId>snowdrop-namespace</artifactId>
-                <version>${version.snowdrop}</version>
-            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
SnowDrop has been deprecated in WFK2 and will not be supported in EAP7.
