### PR TITLE
Updated versions of Arquillian-core and of other Arquillian components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <!-- Versions of JBoss projects -->
         <version.org.wildfly>10.0.0.CR3</version.org.wildfly>
         <version.org.infinispan>8.0.1.Final</version.org.infinispan>
-        <version.org.jboss.arquillian>1.1.9.Final</version.org.jboss.arquillian>
+        <version.org.jboss.arquillian>1.1.10.Final</version.org.jboss.arquillian>
         <version.org.jboss.arquillian.extension.drone>2.0.0.Alpha5</version.org.jboss.arquillian.extension.drone>
         <version.org.jboss.arquillian.graphene>2.0.3.Final</version.org.jboss.arquillian.graphene>
         <version.org.wildfly.arquillian.container>1.1.0.Alpha1</version.org.wildfly.arquillian.container>


### PR DESCRIPTION
updated version of:
Arquillian-core to 1.1.9.Final
wildfly-arquillian-container adapters to 1.1.0.Alpha1 - see: JBEAP-579
ShrinkWrap Resolver to 2.2.0 - there has been also replaced the depchain with the Resolver's BOM - to manage versions of transitive dependencies
