### PR TITLE
Updated to Spring Core 4.3.2 and related updates

### DIFF
--- a/jboss-javaee7-with-spring4/pom.xml
+++ b/jboss-javaee7-with-spring4/pom.xml
@@ -26,9 +26,9 @@
 
     <properties>
         <!-- Versions of Spring Projects -->
-        <version.org.springframework>4.2.6.RELEASE</version.org.springframework>
-        <version.org.springframework.security>4.1.0.RELEASE</version.org.springframework.security>
-        <version.org.springframework.webflow>2.4.2.RELEASE</version.org.springframework.webflow>
+        <version.org.springframework>4.3.2.RELEASE</version.org.springframework>
+        <version.org.springframework.security>4.1.3.RELEASE</version.org.springframework.security>
+        <version.org.springframework.webflow>2.4.4.RELEASE</version.org.springframework.webflow>
         <version.org.springframework.ws>2.3.0.RELEASE</version.org.springframework.ws>
         
         <!-- Versions of Spring Third Party dependencies -->


### PR DESCRIPTION
Tested on both EAP 7.0.2.CP.CR1 and EAP 7.1.0.DR3, should be safe.
