### PR TITLE
JBEAP-10893 Add more managed dependencies to align bit more with upstream

### DIFF
--- a/jboss-javaee7-with-spring4/pom.xml
+++ b/jboss-javaee7-with-spring4/pom.xml
@@ -26,10 +26,10 @@
 
     <properties>
         <!-- Versions of Spring Projects -->
-        <version.org.springframework>4.3.2.RELEASE</version.org.springframework>
-        <version.org.springframework.security>4.1.3.RELEASE</version.org.springframework.security>
-        <version.org.springframework.webflow>2.4.4.RELEASE</version.org.springframework.webflow>
-        <version.org.springframework.ws>2.3.0.RELEASE</version.org.springframework.ws>
+        <version.org.springframework>4.3.10.RELEASE</version.org.springframework>
+        <version.org.springframework.security>4.1.4.RELEASE</version.org.springframework.security>
+        <version.org.springframework.webflow>2.4.5.RELEASE</version.org.springframework.webflow>
+        <version.org.springframework.ws>2.3.1.RELEASE</version.org.springframework.ws>
         
         <!-- Versions of Spring Third Party dependencies -->
         <version.aopalliance>1.0</version.aopalliance>

--- a/jboss-javaee7-with-tools/pom.xml
+++ b/jboss-javaee7-with-tools/pom.xml
@@ -113,25 +113,4 @@
         </dependencies>
     </dependencyManagement>
 
-    <build>
-        <pluginManagement>
-            <plugins>
-                <!-- The Maven Surefire plugin tests your application. Here
-                    we ensure we are using a version compatible with Arquillian -->
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${version.surefire.plugin}</version>
-                </plugin>
-                <!-- The WildFly plugin deploys your war to a local WildFly container -->
-                <!-- To use, set the JBOSS_HOME environment variable and
-                    run: mvn package wildfly:deploy -->
-                <plugin>
-                    <groupId>org.wildfly.plugins</groupId>
-                    <artifactId>wildfly-maven-plugin</artifactId>
-                    <version>${version.org.wildfly.plugins.maven.plugin}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,31 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2016, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>jboss-parent</artifactId>
+        <groupId>org.jboss</groupId>
+        <version>24</version>
+    </parent>
 
     <groupId>org.jboss.bom</groupId>
     <artifactId>jboss-eap-javaee7</artifactId>
@@ -14,12 +37,16 @@
     <description>JBoss EAP Java EE 7 Dependency Management</description>
 
     <url>http://www.jboss.org</url>
-    <issueManagement>
-        <system>JIRA</system>
-        <url>https://issues.jboss.org/</url>
-    </issueManagement>
 
-    <scm>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+<scm>
         <connection>scm:git:git@github.com:jboss-developer/jboss-eap-boms.git</connection>
         <developerConnection>scm:git:git@github.com:jboss-developer/jboss-eap-boms.git</developerConnection>
         <url>http://github.com/jboss-developer/jboss-eap-boms</url>
@@ -34,27 +61,30 @@
         </developer>
     </developers>
 
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
+    <issueManagement>
+        <system>JIRA</system>
+        <url>https://issues.jboss.org/</url>
+    </issueManagement>
 
     <properties>
 
+   <version.org.jboss.eap>7.1.0.GA-redhat-4</version.org.jboss.eap>
         <!-- Versions of JBoss projects -->
-        <version.org.jboss.eap>7.1.0.GA-redhat-4</version.org.jboss.eap>
+
+        <version.io.undertow>1.4.18.Final-redhat-1</version.io.undertow>
+        <version.io.undertow.js>1.0.2.Final-redhat-1</version.io.undertow.js>
+
+        <version.org.apache.cxf>3.1.12</version.org.apache.cxf>
         <version.org.infinispan>8.2.8.Final-redhat-1</version.org.infinispan>
         <version.org.jboss.arquillian>1.1.13.Final</version.org.jboss.arquillian>
-        <version.org.jboss.arquillian.extension.drone>2.0.1.Final</version.org.jboss.arquillian.extension.drone>
-        <version.org.jboss.arquillian.graphene>2.1.0.Final</version.org.jboss.arquillian.graphene>
+        <version.org.jboss.arquillian.extension.drone>2.3.1</version.org.jboss.arquillian.extension.drone>
+        <version.org.jboss.arquillian.graphene>2.3.1</version.org.jboss.arquillian.graphene>
         <version.org.wildfly.arquillian.container>2.0.1.Final</version.org.wildfly.arquillian.container>
-        <version.org.jboss.narayana>5.5.29.Final-redhat-1</version.org.jboss.narayana>
         <version.org.jboss.ejb3.ext-api>2.2.0.Final-redhat-1</version.org.jboss.ejb3.ext-api>
+        <version.org.jboss.jboss-dmr>1.4.1.Final-redhat-1</version.org.jboss.jboss-dmr>
         <version.org.jboss.logging.jboss-logging>3.3.1.Final-redhat-1</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.logging.processor>2.0.1.Final-redhat-1</version.org.jboss.logging.processor>
+        <version.org.jboss.logging.jboss-logging-tools>2.0.1.Final-redhat-1</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.narayana>5.5.29.Final-redhat-1</version.org.jboss.narayana>
         <version.org.jboss.resteasy>3.0.24.Final-redhat-1</version.org.jboss.resteasy>
         <version.org.jboss.security.jboss-negotiation>3.0.4.Final-redhat-1</version.org.jboss.security.jboss-negotiation>
         <version.org.jboss.security.jbossxacml>2.0.8.Final-redhat-8</version.org.jboss.security.jbossxacml>
@@ -64,6 +94,10 @@
         <version.org.picketbox.picketbox-commons>1.0.0.final-redhat-5</version.org.picketbox.picketbox-commons>
         <version.org.picketlink>2.5.5.SP7-redhat-2</version.org.picketlink>
         <version.org.glassfish.jaxb>2.2.11.redhat-4</version.org.glassfish.jaxb>
+        <version.org.wildfly.security.elytron>1.1.0.CR4-redhat-1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.client.config>1.0.0.CR3-redhat-1</version.org.wildfly.client.config>
+        <version.org.wildfly.common>1.2.0.CR1-redhat-1</version.org.wildfly.common>
+        <version.org.wildfly.discovery>1.0.0.CR1-redhat-1</version.org.wildfly.discovery>
 
         <!-- Version of Hibernate projects -->
         <version.org.hibernate>5.1.9.Final-redhat-1</version.org.hibernate>
@@ -74,15 +108,15 @@
 
         <!-- Versions of projects not directly under JBoss umbrella -->
         <version.junit>4.12</version.junit>
-        <version.log4j>1.2.16</version.log4j>
-        <version.org.testng>6.1.1</version.org.testng>
-
-        <!-- Versions of Maven plugins, user must setup them by his/her own -->
-        <version.surefire.plugin>2.17</version.surefire.plugin>
-        <version.org.wildfly.plugins.maven.plugin>1.0.2.Final</version.org.wildfly.plugins.maven.plugin>
-
+        <version.log4j>1.2.17</version.log4j>
+        <version.org.slf4j>1.7.7</version.org.slf4j>
+        <version.org.testng>6.9.10</version.org.testng>
     </properties>
 
+    <modules>
+        <module>jboss-javaee7-with-spring4</module>
+        <module>jboss-javaee7-with-tools</module>
+    </modules>
     <dependencyManagement>
         <dependencies>
         <!-- BOM imports -->
@@ -121,6 +155,84 @@
 
         <!-- Individual EAP Components -->
 
+            <dependency>
+                <groupId>io.undertow</groupId>
+                <artifactId>undertow-core</artifactId>
+                <version>${version.io.undertow}</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>undertow-build-config</artifactId>
+                        <groupId>io.undertow</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.undertow</groupId>
+                <artifactId>undertow-servlet</artifactId>
+                <version>${version.io.undertow}</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>undertow-build-config</artifactId>
+                        <groupId>io.undertow</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>jboss-jsp-api_2.2_spec</artifactId>
+                        <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.undertow</groupId>
+                <artifactId>undertow-websockets-jsr</artifactId>
+                <version>${version.io.undertow}</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>undertow-build-config</artifactId>
+                        <groupId>io.undertow</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.undertow.js</groupId>
+                <artifactId>undertow-js</artifactId>
+                <version>${version.io.undertow.js}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron</artifactId>
+                <version>${version.org.wildfly.security.elytron}</version>
+                <scope>provided</scope>
+            </dependency>
+
+
+            <dependency>
+                <groupId>org.wildfly.discovery</groupId>
+                <artifactId>wildfly-discovery-client</artifactId>
+                <version>${version.org.wildfly.discovery}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.client</groupId>
+                <artifactId>wildfly-client-config</artifactId>
+                <version>${version.org.wildfly.client.config}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.common</groupId>
+                <artifactId>wildfly-common</artifactId>
+                <version>${version.org.wildfly.common}</version>
+                <scope>provided</scope>
+            </dependency>
+
+
             <!-- Note, these jaxb jars are part of the private EAP 7 and should
             not be used directly.  They are included here only because they are
             transitive dependencies of jbossws-cxf-client -->
@@ -128,16 +240,19 @@
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-core</artifactId>
                 <version>${version.org.glassfish.jaxb}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
                 <version>${version.org.glassfish.jaxb}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-xjc</artifactId>
                 <version>${version.org.glassfish.jaxb}</version>
+                <scope>provided</scope>
             </dependency>
 
             <!-- Hibernate ORM sub-modules -->
@@ -157,11 +272,13 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-entitymanager</artifactId>
                 <version>${version.org.hibernate}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-envers</artifactId>
                 <version>${version.org.hibernate}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
@@ -179,36 +296,43 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-c3p0</artifactId>
                 <version>${version.org.hibernate}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-ehcache</artifactId>
                 <version>${version.org.hibernate}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-proxool</artifactId>
                 <version>${version.org.hibernate}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${version.org.hibernate.validator}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-search-engine</artifactId>
                 <version>${version.org.hibernate.search}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-search-orm</artifactId>
                 <version>${version.org.hibernate.search}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-directory-provider</artifactId>
                 <version>${version.org.infinispan}</version>
+                <scope>provided</scope>
             </dependency>
             <!-- Tools -->
             <dependency>
@@ -239,6 +363,14 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jboss</groupId>
+                <artifactId>jboss-dmr</artifactId>
+                <version>${version.org.jboss.jboss-dmr}</version>
+                <scope>provided</scope>
+            </dependency>
+
+
+            <dependency>
                 <groupId>org.jboss.ejb3</groupId>
                 <artifactId>jboss-ejb3-ext-api</artifactId>
                 <version>${version.org.jboss.ejb3.ext-api}</version>
@@ -255,13 +387,13 @@
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging-processor</artifactId>
-                <version>${version.org.jboss.logging.processor}</version>
+                <version>${version.org.jboss.logging.jboss-logging-tools}</version>
             </dependency>
             <!--  the jboss-logging-tools annotations  -->
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging-annotations</artifactId>
-                <version>${version.org.jboss.logging.processor}</version>
+                <version>${version.org.jboss.logging.jboss-logging-tools}</version>
             </dependency>
             <!--  jboss-logging API -->
             <dependency>
@@ -275,9 +407,9 @@
                 <groupId>org.jboss.narayana.xts</groupId>
                 <artifactId>jbossxts</artifactId>
                 <version>${version.org.jboss.narayana}</version>
-                <scope>provided</scope>
                 <classifier>api</classifier>
-            </dependency>
+                <scope>provided</scope>
+                </dependency>
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
@@ -438,28 +570,34 @@
                 <artifactId>log4j</artifactId>
                 <version>${version.log4j}</version>
             </dependency>
-
+            <!--Apache CXF -->
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-core</artifactId>
+                <version>${version.org.apache.cxf}</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.ws.xmlschema</groupId>
+                        <artifactId>xmlschema-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-javamail_1.4_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>xalan</groupId>
+                        <artifactId>xalan</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>
-
-    <modules>
-        <module>jboss-javaee7-with-spring4</module>
-        <module>jboss-javaee7-with-tools</module>
-    </modules>
-
-    <distributionManagement>
-        <repository>
-            <id>jboss-releases-repository</id>
-            <name>JBoss Releases Repository</name>
-            <url>${jboss.releases.repo.url}</url>
-        </repository>
-        <snapshotRepository>
-            <id>jboss-snapshots-repository</id>
-            <name>JBoss Snapshots Repository</name>
-            <url>${jboss.snapshots.repo.url}</url>
-        </snapshotRepository>
-    </distributionManagement>
 
     <profiles>
         <profile>
@@ -469,7 +607,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.4</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
add
- elytron
- undertow
- wildfly-common
- wildfly-discovery

update versions of Spring boms to the latest agreed upon.

remove maven plugin versions as they are not taken into account when importing bom into user's pom.
they only make affect if you add bom as parent, which is intended scenario.
